### PR TITLE
Bump up #information when screen width < 800px

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -54,6 +54,12 @@ h1{
 	right: 10px;
 	bottom: 5px;	
 }
+/* Bump up div when screen size forces overlap with save/load buttons */
+@media only screen and (max-width: 800px){
+	#information{
+		bottom: 25px;
+	}
+}
 
 /* Advert */
 #advert{


### PR DESCRIPTION
When screen is less than 800px wide, the #information div overlaps with the save and load divs.  this @media query fixes that by moving #information up by 20px when screen < 800px.
